### PR TITLE
docs: link to marimo docs for mdx, SSGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ Sphinx** that target marimo snippets.
 * If you develop a plugin, let us know and we'll link to it from our README.
 * If you have questions while developing a plugin, reach out on GitHub issues.
 
+marimo snippets is implemented as a wrapper around marimo's online playground;
+In some cases, when building plugins for SSGs, you may be better served by generating
+working with playground URLs directly, instead of using marimo-snippets. Consult
+the marimo [docs on embedding playground
+notebooks](https://docs.marimo.io/guides/publishing/playground/#embedding-in-other-web-pages)
+to learn more.
+
 ## Configuration
 
 marimo snippets can be configured in two ways: globally, or locally for individual snippets.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ many static site generators like mkdocs. However, marimo snippets does not work
 out of the box with all SSGs; for example, it does not work out of the box with
 Sphinx.
 
+### MDX
+
+marimo-snippets does not play well with MDX out of the box. To embed marimo
+notebooks in MDX, see the [marimo
+documentation](https://docs.marimo.io/guides/publishing/playground/#mdx).
+
 ### Contributing
 
 To our community: **we'd love your help in developing plugins for other SSGs like

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Sphinx** that target marimo snippets.
 * If you develop a plugin, let us know and we'll link to it from our README.
 * If you have questions while developing a plugin, reach out on GitHub issues.
 
-marimo snippets is implemented as a wrapper around marimo's online playground;
+marimo snippets is implemented as a wrapper around marimo's online playground.
 In some cases, when building plugins for SSGs, you may be better served by generating
 working with playground URLs directly, instead of using marimo-snippets. Consult
 the marimo [docs on embedding playground


### PR DESCRIPTION
* The marimo docs have a code snippet for using playground notebooks in MDX, which for MDX easier to get working than marimo-snippets.
* Link to our docs on embedding playground notebooks in the contributing section.